### PR TITLE
update fortmatic sdk to v0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@portis/web3": "^2.0.0-beta.30",
     "@walletconnect/web3-provider": "^1.0.0-beta.25",
-    "fortmatic": "^0.8.0",
+    "fortmatic": "^0.8.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
This new version of the Fortmatic SDK contains compatibility fixes for various web3 beta 1.0 versions.