### PR TITLE
Change Nifty wallet extension name

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -59,7 +59,7 @@ const providers: IProviderInfo[] = [
     }
   },
   {
-    name: "Nifty Wallet",
+    name: "Nifty",
     logo: NiftyWalletLogo,
     type: "injected",
     check: "isNiftyWallet",


### PR DESCRIPTION
to fix doubled *Wallet*

![Screenshot 2019-07-04 at 13 15 09](https://user-images.githubusercontent.com/4341812/60659725-c3c39500-9e5e-11e9-8ceb-86ccc2bf25e3.png)
