### PR TITLE
Disable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ interface IInjectedProvidersMap {
     - key: the secret key (required)
     - network: choose initial network name (optional)
 
+You can disable the injected provider or WalletConnect by adding the following keys:
+
+- disableInjectedProvider: true (optional)
+- disableWalletConnect: true (optional)
+
 ## Collaboration
 
 ### Code contributions are welcome ❤️❤️❤️!

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,15 +236,25 @@ class Modal extends React.Component<IModalProps, IModalState> {
           <SHitbox onClick={onClose} />
           {!hideMainModalCard && (
             <SModalCard ref={c => (this.mainModalCard = c)}>
-              {!!injectedProvider && (
-                <Provider name={injectedProvider} onClick={connectToInjected} />
-              )}
-              {!(injectedProvider && mobile) && (
-                <React.Fragment>
+              {!!injectedProvider &&
+                !providerOptions.disableInjectedProvider && (
                   <Provider
-                    name={"WalletConnect"}
-                    onClick={connectToWalletConnect}
+                    name={injectedProvider}
+                    onClick={connectToInjected}
                   />
+                )}
+              {!(
+                injectedProvider &&
+                !providerOptions.disableInjectedProvider &&
+                mobile
+              ) && (
+                <React.Fragment>
+                  {!providerOptions.disableWalletConnect && (
+                    <Provider
+                      name={"WalletConnect"}
+                      onClick={connectToWalletConnect}
+                    />
+                  )}
                   {displayPortis && (
                     <Provider name={"Portis"} onClick={connectToPortis} />
                   )}


### PR DESCRIPTION
Some developers may need to not show Injected providers or WalletConnect by Default (#39). By default, those are going to show but I've added props that if included it will not show the Injected Provider or WalletConnect