### PR TITLE
fixed modal on Portis

### DIFF
--- a/src/core/connectors/portis.ts
+++ b/src/core/connectors/portis.ts
@@ -12,10 +12,8 @@ const ConnectToPortis = async (opts: IPortisConnectorOptions) => {
         const id = opts.id;
         const network = opts.network || "mainnet";
         const pt = new Portis(id, network);
-        pt.onLogin(() => {
-          resolve(pt.provider);
-        });
-        await pt.showPortis();
+        await pt.provider.enable();
+        resolve(pt.provider);
       } catch (error) {
         return reject(error);
       }


### PR DESCRIPTION
Portis now connects directly and no additional wallet pop up is shown