### PR TITLE
Enable GasRelay on Portis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -927,13 +927,14 @@
       }
     },
     "@portis/web3": {
-      "version": "2.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@portis/web3/-/web3-2.0.0-beta.30.tgz",
-      "integrity": "sha512-WXrq022H2HO1dG0T8BGRbXksK4dRY79Do1c8PS21+ewuuSWLCs4KJ5NYaFtNnaSm+gFC04XB4fWEbZpENBur6A==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@portis/web3/-/web3-2.0.0-beta.36.tgz",
+      "integrity": "sha512-wl6yxF2yoDG3KsVa1dGUb0G0FbygIhi4uG/nyelluJQTd9KLKb354DUNOdjQRQgqrlbMHPLOvJ3I1Ud8vggdww==",
       "requires": {
         "@portis/web3-provider-engine": "1.0.10",
         "ethereumjs-util": "5.2.0",
-        "penpal": "3.0.7"
+        "penpal": "3.0.7",
+        "pocket-js-core": "0.0.3"
       }
     },
     "@portis/web3-provider-engine": {
@@ -948,7 +949,7 @@
         "eth-block-tracker": "^4.2.0",
         "eth-json-rpc-filters": "^4.0.2",
         "eth-json-rpc-infura": "^3.1.0",
-        "eth-json-rpc-middleware": "github:radotzki/eth-json-rpc-middleware#patch-1",
+        "eth-json-rpc-middleware": "github:radotzki/eth-json-rpc-middleware#8acc43df4a8c0c7f6d212af9163d379211dad4c7",
         "eth-sig-util": "^1.4.2",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
@@ -963,104 +964,6 @@
         "ws": "^5.1.1",
         "xhr": "^2.2.0",
         "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "eth-json-rpc-middleware": {
-          "version": "github:radotzki/eth-json-rpc-middleware#8acc43df4a8c0c7f6d212af9163d379211dad4c7",
-          "from": "github:radotzki/eth-json-rpc-middleware#patch-1",
-          "requires": {
-            "btoa": "^1.2.1",
-            "clone": "^2.1.1",
-            "eth-query": "^2.1.2",
-            "eth-sig-util": "^1.4.2",
-            "ethereumjs-block": "^1.6.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.2",
-            "ethereumjs-vm": "2.2.2",
-            "fetch-ponyfill": "^4.0.0",
-            "json-rpc-engine": "^5.0.0",
-            "json-rpc-error": "^2.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "pify": "^3.0.0",
-            "safe-event-emitter": "^1.0.1"
-          },
-          "dependencies": {
-            "ethereumjs-vm": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.2.2.tgz",
-              "integrity": "sha512-sAus9UxYjUnA42G91Q1/hR7ff35IJRpcLrUfbaIH7V4cl8qKsNs3wqf3dHvtj3wRqy12ke2Wd0tYdARyGKdD6g==",
-              "requires": {
-                "async": "^2.1.2",
-                "async-eventemitter": "^0.2.2",
-                "ethereum-common": "0.1.0",
-                "ethereumjs-account": "^2.0.3",
-                "ethereumjs-block": "~1.6.0",
-                "ethereumjs-util": "4.5.0",
-                "fake-merkle-patricia-tree": "^1.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "merkle-patricia-tree": "^2.1.2",
-                "safe-buffer": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-block": {
-                  "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.6.0.tgz",
-                  "integrity": "sha1-ze1JYt6soe7xc3K00pDoSzXIQ3I=",
-                  "requires": {
-                    "async": "^2.0.1",
-                    "ethereum-common": "0.0.18",
-                    "ethereumjs-tx": "^1.2.2",
-                    "ethereumjs-util": "^5.0.0",
-                    "merkle-patricia-tree": "^2.1.2"
-                  },
-                  "dependencies": {
-                    "ethereum-common": {
-                      "version": "0.0.18",
-                      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-                      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-                    },
-                    "ethereumjs-util": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-                      "requires": {
-                        "bn.js": "^4.11.0",
-                        "create-hash": "^1.1.2",
-                        "ethjs-util": "^0.1.3",
-                        "keccak": "^1.0.2",
-                        "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1",
-                        "secp256k1": "^3.0.1"
-                      }
-                    }
-                  }
-                },
-                "ethereumjs-util": {
-                  "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                  "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-                  "requires": {
-                    "bn.js": "^4.8.0",
-                    "create-hash": "^1.1.2",
-                    "keccakjs": "^0.2.0",
-                    "rlp": "^2.0.0",
-                    "secp256k1": "^3.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ethereum-common": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.1.0.tgz",
-          "integrity": "sha1-h03Q+uXpYqVsUOvyjvpv45SSsOc="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
       }
     },
     "@types/node": {
@@ -1173,7 +1076,7 @@
         "@walletconnect/browser": "^1.0.0-beta.32",
         "@walletconnect/qrcode-modal": "^1.0.0-beta.32",
         "@walletconnect/types": "^1.0.0-beta.32",
-        "web3-provider-engine": "github:walletconnect/web3-provider-engine"
+        "web3-provider-engine": "github:walletconnect/web3-provider-engine#3db8919ecd236e27af0577a00b4922b20da63bf9"
       }
     },
     "@webassemblyjs/ast": {
@@ -1599,9 +1502,9 @@
       }
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1628,6 +1531,22 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -3710,9 +3629,8 @@
       }
     },
     "eth-json-rpc-middleware": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.1.3.tgz",
-      "integrity": "sha512-g663u/zK11huhkmP7jeFihUcwA2acYglIw2wO50G7zIXYoZ6L+NHJjEwW7gwVMEUy7rgB3Qx76ql/+UYJfIb9w==",
+      "version": "github:radotzki/eth-json-rpc-middleware#8acc43df4a8c0c7f6d212af9163d379211dad4c7",
+      "from": "github:radotzki/eth-json-rpc-middleware#patch-1",
       "requires": {
         "btoa": "^1.2.1",
         "clone": "^2.1.1",
@@ -3721,7 +3639,7 @@
         "ethereumjs-block": "^1.6.0",
         "ethereumjs-tx": "^1.3.3",
         "ethereumjs-util": "^5.1.2",
-        "ethereumjs-vm": "^2.6.0",
+        "ethereumjs-vm": "2.2.2",
         "fetch-ponyfill": "^4.0.0",
         "json-rpc-engine": "^5.0.0",
         "json-rpc-error": "^2.0.0",
@@ -3730,6 +3648,75 @@
         "safe-event-emitter": "^1.0.1"
       },
       "dependencies": {
+        "ethereum-common": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.1.0.tgz",
+          "integrity": "sha1-h03Q+uXpYqVsUOvyjvpv45SSsOc="
+        },
+        "ethereumjs-vm": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.2.2.tgz",
+          "integrity": "sha512-sAus9UxYjUnA42G91Q1/hR7ff35IJRpcLrUfbaIH7V4cl8qKsNs3wqf3dHvtj3wRqy12ke2Wd0tYdARyGKdD6g==",
+          "requires": {
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
+            "ethereum-common": "0.1.0",
+            "ethereumjs-account": "^2.0.3",
+            "ethereumjs-block": "~1.6.0",
+            "ethereumjs-util": "4.5.0",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.1.2",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-block": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.6.0.tgz",
+              "integrity": "sha1-ze1JYt6soe7xc3K00pDoSzXIQ3I=",
+              "requires": {
+                "async": "^2.0.1",
+                "ethereum-common": "0.0.18",
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
+              },
+              "dependencies": {
+                "ethereum-common": {
+                  "version": "0.0.18",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+                  "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+                },
+                "ethereumjs-util": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                  "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "^0.1.3",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
+              }
+            },
+            "ethereumjs-util": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+              "requires": {
+                "bn.js": "^4.8.0",
+                "create-hash": "^1.1.2",
+                "keccakjs": "^0.2.0",
+                "rlp": "^2.0.0",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -3751,7 +3738,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d700d091f79c06f4e27872f4a1d7b153986cc3dd",
         "ethereumjs-util": "^5.1.1"
       }
     },
@@ -3778,7 +3765,7 @@
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d700d091f79c06f4e27872f4a1d7b153986cc3dd",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -3797,6 +3784,59 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "keccak": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+              "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "rlp": {
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+              "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+              "requires": {
+                "bn.js": "^4.11.1",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "secp256k1": {
+              "version": "3.7.1",
+              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+              "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+              "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.4.1",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+              },
+              "dependencies": {
+                "nan": {
+                  "version": "2.14.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+                  "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+                }
+              }
+            }
           }
         }
       }
@@ -3824,9 +3864,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.1.0.tgz",
-      "integrity": "sha512-LUmYkKV/HcZbWRyu3OU9YOevsH3VJDXtI6kEd8VZweQec+JjDGKCmAVKUyzhYUHqxRJu7JNALZ3A/b3NXOP6tA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz",
+      "integrity": "sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -4221,6 +4261,24 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4326,8 +4384,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4348,14 +4405,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4370,20 +4425,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4500,8 +4552,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4513,7 +4564,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4528,7 +4578,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4536,14 +4585,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4562,7 +4609,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4643,8 +4689,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4656,7 +4701,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4742,8 +4786,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4779,7 +4822,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4799,7 +4841,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4843,14 +4884,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4909,6 +4948,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5611,9 +5651,9 @@
       "dev": true
     },
     "json-rpc-engine": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.0.0.tgz",
-      "integrity": "sha512-bxzuHwoP/U7xBIcqxP9QaOMgW7GDbBNU2TLNWfndRfHxwPLKkGMBfgtns0oDvgjMPJLCgyFZjrnVuSHW5GSC7A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.1.1.tgz",
+      "integrity": "sha512-+2rEKzbEtKq9MPluZIbq60XIToQa3rN2m35Gu4stShxpo1CKVhISYjKJyizL9/XBmNIiRLjLwDQUT6I/zHgj1g==",
       "requires": {
         "@babel/preset-env": "^7.3.4",
         "async": "^2.0.1",
@@ -6741,6 +6781,14 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pocket-js-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/pocket-js-core/-/pocket-js-core-0.0.3.tgz",
+      "integrity": "sha512-OUTEvEVutdjLT6YyldvAlSebpBueUUWg2XKxGNt5u3QqrmLpBOOBmdDnGMNJ+lEwXtko+JqgwFq+HTi4g1QDVg==",
+      "requires": {
+        "axios": "^0.18.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -6810,9 +6858,9 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -7102,13 +7150,6 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
       }
     },
     "require-directory": {
@@ -7127,6 +7168,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7270,9 +7312,9 @@
       }
     },
     "secp256k1": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-      "integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
       "requires": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
@@ -7280,8 +7322,15 @@
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
         "elliptic": "^6.4.1",
-        "nan": "^2.13.2",
+        "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "semaphore": {
@@ -7771,29 +7820,55 @@
       "dev": true
     },
     "tape": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.1.tgz",
-      "integrity": "sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
       "requires": {
         "deep-equal": "~1.0.1",
         "defined": "~1.0.0",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
-        "glob": "~7.1.3",
+        "glob": "~7.1.4",
         "has": "~1.0.3",
-        "inherits": "~2.0.3",
+        "inherits": "~2.0.4",
         "minimist": "~1.2.0",
         "object-inspect": "~1.6.0",
-        "resolve": "~1.10.0",
+        "resolve": "~1.11.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
@@ -8277,6 +8352,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "v8-compile-cache": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
@@ -8333,7 +8413,7 @@
       }
     },
     "web3-provider-engine": {
-      "version": "github:walletconnect/web3-provider-engine#48080be33018e8f24e4ba80ccb76787a33ed3e9b",
+      "version": "github:walletconnect/web3-provider-engine#3db8919ecd236e27af0577a00b4922b20da63bf9",
       "from": "github:walletconnect/web3-provider-engine",
       "requires": {
         "async": "^2.5.0",
@@ -8343,7 +8423,7 @@
         "eth-block-tracker": "^4.2.0",
         "eth-json-rpc-filters": "^4.0.2",
         "eth-json-rpc-infura": "^3.1.0",
-        "eth-json-rpc-middleware": "github:walletconnect/eth-json-rpc-middleware",
+        "eth-json-rpc-middleware": "github:walletconnect/eth-json-rpc-middleware#dac43613b9f1bf9d45455dcb98cbb8f676f61a8a",
         "eth-sig-util": "^1.4.2",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@portis/web3": "^2.0.0-beta.30",
+    "@portis/web3": "^2.0.0-beta.34",
     "@walletconnect/web3-provider": "^1.0.0-beta.32",
     "fortmatic": "^0.8.1",
     "prop-types": "^15.7.2",

--- a/src/core/connectors/portis.ts
+++ b/src/core/connectors/portis.ts
@@ -1,8 +1,24 @@
 import Portis from "@portis/web3";
 
+export interface INetwork {
+  nodeUrl: string;
+  chainId?: string;
+  gasRelayHubAddress?: string;
+}
+
+export type Scope = 'email';
+
+export interface IOptions {
+  scope?: Scope[];
+  gasRelay?: boolean;
+  registerPageByDefault?: boolean;
+  pocketDevId?: string;
+}
+
 export interface IPortisConnectorOptions {
   id: string;
-  network?: string;
+  network?: string | INetwork;
+  config?: IOptions;
 }
 
 const ConnectToPortis = async (opts: IPortisConnectorOptions) => {
@@ -11,8 +27,10 @@ const ConnectToPortis = async (opts: IPortisConnectorOptions) => {
       try {
         const id = opts.id;
         const network = opts.network || "mainnet";
-        const pt = new Portis(id, network);
+        const config = opts.config;
+        const pt = new Portis(id, network, config);
         await pt.provider.enable();
+        pt.provider._portis = pt;
         resolve(pt.provider);
       } catch (error) {
         return reject(error);


### PR DESCRIPTION
In order to enable the GasRelay on Portis, it is required to allow to send different [network & config parameters](https://docs.portis.io/#/configuration) when creating a new instance. Changes in this PR include proper interfaces to accept all Portis config params.

Portis also offer different [methods](https://docs.portis.io/#/methods?id=showportis) to control the wallet and network connection. If web3connect only returns the provider, dApp lose the access to these useful methods. To overcome this, the new Portis instance is included within the provider instance.