### PR TITLE
add  Connect method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See Providers Options Section for each provider
 3. Then you can add Web3Connect to your Dapp as follows
 
 ```js
+import Web3 from "web3";
 import Web3Connect from "web3connect";
 
 const providerOptions = {
@@ -58,20 +59,13 @@ const providerOptions = {
 
 const web3Connect = new Web3Connect.Core({
   network: "mainnet", // optional
-  providerOptions: providerOptions
+  cacheProvider: true, // optional
+  providerOptions // required
 });
 
-// subscribe to connect
-web3Connect.on("connect", (provider: any) => {
-  const web3 = new Web3(provider); // add provider to web3
-});
+const provider = await web3Connect.connect();
 
-// subscribe to close
-web3Connect.on("close", () => {
-  console.log("Web3Connect Modal Closed"); // modal has closed
-});
-
-web3Connect.toggleModal(); // open modal on button click
+const web = new Web3(provider);
 ```
 
 ## Provider Options
@@ -305,37 +299,46 @@ function getInjectedProviderName(): string | null;
 function getProviderInfoByName(name: string | null): IProviderInfo;
 function getProviderInfo(provider: any): IProviderInfo;
 function isMobile(): boolean;
-function formatProviderDescription(providerInfo: IProviderInfo);
 ```
 
 ## Types
 
 ```typescript
-interface IProviderInfo {
-  name: string;
-  type: string;
-  logo: string;
-  check: string;
-  styled: {
-    [prop: string]: any;
-  };
-}
-
-interface IProviderOptions {
-  [providerName: string]: {
-    package: any;
-    options: any;
-  };
-}
-
 interface IInjectedProvidersMap {
   injectedAvailable: boolean;
   [isProviderName: string]: boolean;
 }
 
-interface IProviderCallback {
-  name: string | null;
-  onClick: () => Promise<void>;
+interface IProviderInfo {
+  id: string;
+  name: string;
+  type: string;
+  logo: string;
+  check: string;
+  package: IProviderPackageOptions;
+  styled: IProviderStyledOptions;
+}
+
+interface IProviderPackageOptions {
+  required: string[];
+}
+
+interface IProviderStyledOptions {
+  [prop: string]: any;
+}
+
+interface IProviderOptions {
+  [id: string]: {
+    package: any;
+    options: any;
+  };
+}
+
+interface IProviderMappingEntry {
+  id: string;
+  name: string;
+  connector: any;
+  package: IProviderPackageOptions;
 }
 ```
 

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -105,6 +105,11 @@ class Core {
     await this._toggleModal();
   };
 
+  public connect = () =>  new Promise(async (resolve, reject) => {
+    await this.toggleModal()
+    this.on('connect', (provider) => resolve(provider))
+  })
+
   public renderModal() {
     const el = document.createElement("div");
     el.id = WEB3_CONNECT_MODAL_ID;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -19,6 +19,11 @@ export interface IProviderControllerOptions {
   network: string;
 }
 
+export interface IInjectedProvidersMap {
+  injectedAvailable: boolean;
+  [isProviderName: string]: boolean;
+}
+
 export interface IProviderInfo {
   id: string;
   name: string;
@@ -27,6 +32,10 @@ export interface IProviderInfo {
   check: string;
   package: IProviderPackageOptions;
   styled: IProviderStyledOptions;
+}
+
+export interface IProviderPackageOptions {
+  required: string[];
 }
 
 export interface IProviderStyledOptions {
@@ -40,23 +49,6 @@ export interface IProviderOptions {
   };
 }
 
-export type SimpleFunction = (input?: any) => void;
-
-export interface IEventCallback {
-  event: string;
-  callback: (result: any) => void;
-}
-
-export interface IInjectedProvidersMap {
-  injectedAvailable: boolean;
-  [isProviderName: string]: boolean;
-}
-
-export interface IProviderCallback {
-  name: string | null;
-  onClick: () => Promise<void>;
-}
-
 export interface IProviderMappingEntry {
   id: string;
   name: string;
@@ -64,6 +56,14 @@ export interface IProviderMappingEntry {
   package: IProviderPackageOptions;
 }
 
-export interface IProviderPackageOptions {
-  required: string[];
+export interface IProviderCallback {
+  name: string | null;
+  onClick: () => Promise<void>;
+}
+
+export type SimpleFunction = (input?: any) => void;
+
+export interface IEventCallback {
+  event: string;
+  callback: (result: any) => void;
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -112,7 +112,7 @@ export function isMobile(): boolean {
   return mobile;
 }
 
-export function formatProviderDescription(providerInfo: IProviderInfo) {
+export function formatProviderDescription(providerInfo: IProviderInfo): string {
   let description = "";
   switch (providerInfo.type) {
     case "injected":


### PR DESCRIPTION
Simplifying API to a single promise method called `connect()`

**Example**
```javascript
const web3Connect = new Web3Connect.Core(...options)
const provider = await web3Connect.connect();
```